### PR TITLE
Refine day plan selection and budgeting

### DIFF
--- a/src/engine/createPlan.ts
+++ b/src/engine/createPlan.ts
@@ -6,6 +6,7 @@ import type {
   PriceLevel,
   CityStay,
   TravelLeg,
+  PlaceLite,
 } from "../types";
 import { geocodePlace, nearbyPlaces, getTravelTimeMinutes } from "../services/maps";
 import { proposeCitiesForCountry } from "../services/openai";
@@ -42,6 +43,153 @@ function estimateActivityCostFromPriceLevel(category: Interest, pl?: PriceLevel)
   return defaultByCategory[category];
 }
 
+type MealType = "breakfast" | "lunch" | "dinner";
+
+const MEAL_ORDER: MealType[] = ["breakfast", "lunch", "dinner"];
+
+const MIN_MEAL_COST: Record<MealType, number> = {
+  breakfast: 6,
+  lunch: 11,
+  dinner: 18,
+};
+
+const MIN_ACTIVITY_SLOT_COST = 8;
+
+type MealSelection = { place: PlaceLite; cost: number };
+
+type ActivityCandidate = PlaceLite & { _category?: Interest };
+
+type ActivitySelection = { place: ActivityCandidate; cost: number; category: Interest };
+
+function sortPlacesByQuality<T extends { rating?: number; userRatingsTotal?: number; priceLevel?: PriceLevel; name?: string }>(
+  places: T[],
+): T[] {
+  return [...places].sort((a, b) => {
+    const ratingDiff = (b.rating ?? 0) - (a.rating ?? 0);
+    if (Math.abs(ratingDiff) > 0.15) return ratingDiff;
+    const reviewsDiff = (b.userRatingsTotal ?? 0) - (a.userRatingsTotal ?? 0);
+    if (reviewsDiff !== 0) return reviewsDiff;
+    const priceDiff = (a.priceLevel ?? 2) - (b.priceLevel ?? 2);
+    if (priceDiff !== 0) return priceDiff;
+    const nameA = (a as any).name ?? "";
+    const nameB = (b as any).name ?? "";
+    return nameA.localeCompare(nameB);
+  });
+}
+
+function chooseMealCandidate(options: {
+  mealType: MealType;
+  sortedCandidates: PlaceLite[];
+  usedIds: Set<string>;
+  allowReuse: boolean;
+  remainingBudget: number;
+  remainingMeals: MealType[];
+}): MealSelection | undefined {
+  const { mealType, sortedCandidates, usedIds, allowReuse, remainingBudget, remainingMeals } = options;
+  const safeRemaining = Math.max(0, remainingBudget);
+  const minRemaining = remainingMeals.reduce((sum, type) => sum + MIN_MEAL_COST[type], 0);
+  const baseAllowance = Math.max(
+    MIN_MEAL_COST[mealType],
+    Math.min(safeRemaining - minRemaining, safeRemaining),
+  );
+  const target = Number.isFinite(baseAllowance) ? baseAllowance : MIN_MEAL_COST[mealType];
+  const tolerance = Math.max(4, target * 0.35);
+  const limit = Math.min(safeRemaining, target + tolerance);
+
+  let fallback: MealSelection | undefined;
+
+  for (const candidate of sortedCandidates) {
+    if (!candidate) continue;
+    if (!allowReuse && usedIds.has(candidate.id)) continue;
+    const cost = estimateMealCostFromPriceLevel(mealType, candidate.priceLevel);
+    if (!fallback) {
+      fallback = { place: candidate, cost };
+    } else if (cost < fallback.cost - 2) {
+      fallback = { place: candidate, cost };
+    } else if (Math.abs(cost - fallback.cost) <= 2) {
+      const fallbackRating = fallback.place.rating ?? 0;
+      const candidateRating = candidate.rating ?? 0;
+      if (candidateRating > fallbackRating) {
+        fallback = { place: candidate, cost };
+      }
+    }
+    if (cost <= limit + 2) {
+      return { place: candidate, cost };
+    }
+  }
+
+  return fallback;
+}
+
+function chooseActivityCandidate(options: {
+  sortedCandidates: ActivityCandidate[];
+  usedIds: Set<string>;
+  blockedIds: Set<string>;
+  allowReuse: boolean;
+  budgetRemaining: number;
+  slotsRemaining: number;
+}): ActivitySelection | undefined {
+  const { sortedCandidates, usedIds, blockedIds, allowReuse, budgetRemaining, slotsRemaining } = options;
+
+  const skipUsed = (candidate: ActivityCandidate) => !allowReuse && usedIds.has(candidate.id);
+
+  let base = sortedCandidates.filter((candidate) => !skipUsed(candidate));
+  if (!base.length) {
+    base = [...sortedCandidates];
+  }
+  let withoutBlocked = base.filter((candidate) => !blockedIds.has(candidate.id));
+  if (!withoutBlocked.length) {
+    withoutBlocked = base;
+  }
+  let available = withoutBlocked;
+  if (!available.length) {
+    available = [...sortedCandidates];
+  }
+  if (!available.length) return undefined;
+
+  const scored = available.map<ActivitySelection>((candidate) => {
+    const category = (candidate._category ?? "landmarks") as Interest;
+    const cost = estimateActivityCostFromPriceLevel(category, candidate.priceLevel);
+    return { place: candidate, category, cost };
+  });
+
+  const nonFood = scored.filter((item) => item.category !== "food");
+  const pool = nonFood.length ? nonFood : scored;
+
+  const safeRemaining = Math.max(0, budgetRemaining);
+  const reserve = Math.max(0, slotsRemaining * MIN_ACTIVITY_SLOT_COST);
+  const baseAllowance = Math.max(0, Math.min(safeRemaining - reserve, safeRemaining));
+  const tolerance = Math.max(5, baseAllowance * 0.5);
+  const limit = baseAllowance + tolerance;
+
+  const affordable = pool.filter((item) => item.cost <= limit + 2 || safeRemaining === 0);
+  const consider = (affordable.length ? affordable : pool).slice();
+
+  consider.sort((a, b) => {
+    if (affordable.length) {
+      const ratingDiff = (b.place.rating ?? 0) - (a.place.rating ?? 0);
+      if (Math.abs(ratingDiff) > 0.15) return ratingDiff;
+      const reviewsDiff = (b.place.userRatingsTotal ?? 0) - (a.place.userRatingsTotal ?? 0);
+      if (reviewsDiff !== 0) return reviewsDiff;
+      const costDiff = a.cost - b.cost;
+      if (costDiff !== 0) return costDiff;
+      return (a.place.name ?? "").localeCompare(b.place.name ?? "");
+    }
+    const costDiff = a.cost - b.cost;
+    if (costDiff !== 0) return costDiff;
+    const ratingDiff = (b.place.rating ?? 0) - (a.place.rating ?? 0);
+    if (Math.abs(ratingDiff) > 0.15) return ratingDiff;
+    return (b.place.userRatingsTotal ?? 0) - (a.place.userRatingsTotal ?? 0);
+  });
+
+  return consider[0];
+}
+
+function planStartAfter(activity: Activity | undefined, fallbackStartISO: string, fallbackDuration: number, offsetMinutes: number) {
+  const anchor = activity?.end ?? addMinutes(fallbackStartISO, fallbackDuration);
+  return addMinutes(anchor, offsetMinutes);
+}
+
 function toActivity(p: any, kind: "meal" | "activity", category: Interest, timeISO: string, durationMin: number, mealTag?: "breakfast" | "lunch" | "dinner"): Activity {
   const priceLevel = p.priceLevel as PriceLevel | undefined;
   const estimatedCost =
@@ -65,16 +213,6 @@ function toActivity(p: any, kind: "meal" | "activity", category: Interest, timeI
     end: addMinutes(timeISO, durationMin),
     estimatedCost,
   };
-}
-
-function pick<T>(arr: T[], count = 1): T[] {
-  const copy = [...arr];
-  const out: T[] = [];
-  while (copy.length && out.length < count) {
-    const i = Math.floor(Math.random() * copy.length);
-    out.push(copy.splice(i, 1)[0]);
-  }
-  return out;
 }
 
 function orderCitiesEfficiently(cities: CityStay[]) {
@@ -160,60 +298,234 @@ export async function createDayPlan(params: {
     throw new Error("Day plan expects a city. You entered a country.");
   }
 
-  const lat = g.lat, lng = g.lng;
-  const breakfastTime = new Date(params.dateISO + "T08:00:00").toISOString();
-  const lunchTime     = new Date(params.dateISO + "T12:30:00").toISOString();
-  const dinnerTime    = new Date(params.dateISO + "T19:30:00").toISOString();
+  const lat = g.lat;
+  const lng = g.lng;
+  const breakfastTime = new Date(`${params.dateISO}T08:00:00`).toISOString();
+  const lunchTime = new Date(`${params.dateISO}T12:30:00`).toISOString();
+  const dinnerTime = new Date(`${params.dateISO}T19:30:00`).toISOString();
 
-  const perDay = params.budgetPerDay ?? 80;
-  const mealBucket = perDay * 0.5;
-  const activityBucket = perDay * 0.5;
+  const perDayInput = params.budgetPerDay ?? 80;
+  const perDay = Number.isFinite(perDayInput) && perDayInput > 0 ? perDayInput : 80;
+  const mealBudgetTarget = perDay * 0.5;
 
-  const mealPL: PriceLevel[] = perDay < 50 ? [0,1,2] : perDay < 100 ? [1,2,3] : [2,3,4];
+  const mealPL: PriceLevel[] = perDay < 50 ? [0, 1, 2] : perDay < 100 ? [1, 2, 3] : [2, 3, 4];
 
-  const meals = await findMealsNear(lat, lng, mealPL);
-  if (meals.length < 3) {
-    meals.push(...(await findMealsNear(lat, lng, [0,1,2,3,4], 6000)));
+  let mealOptions = await findMealsNear(lat, lng, mealPL);
+  if (mealOptions.length < 3) {
+    const expanded = await findMealsNear(lat, lng, [0, 1, 2, 3, 4], 6000);
+    mealOptions = mealOptions.concat(expanded);
   }
-  const [b,l,d] = [pick(meals,1)[0], pick(meals,1)[0], pick(meals,1)[0]];
+  if (!mealOptions.length) {
+    throw new Error("No restaurants found for the selected location.");
+  }
 
-  let activities = await findActivitiesNear(lat, lng, params.interests.length ? params.interests : ["landmarks","parks"] as any);
-  if (activities.length < 2) {
-    const extra = await nearbyPlaces({
-      lat, lng, radiusMeters: 5000, includedTypes: ["tourist_attraction","park"], minRating: 4.0, maxResults: 20
+  const mealCandidates = sortPlacesByQuality(mealOptions);
+  const mealSelections: Record<MealType, MealSelection> = {} as Record<MealType, MealSelection>;
+  const uniqueMealIds = new Set(mealOptions.map((m) => m.id));
+  const allowMealReuse = uniqueMealIds.size < MEAL_ORDER.length;
+  const usedMealIds = new Set<string>();
+  let remainingMealBudget = mealBudgetTarget;
+
+  for (let i = 0; i < MEAL_ORDER.length; i++) {
+    const mealType = MEAL_ORDER[i];
+    const remainingMeals = MEAL_ORDER.slice(i + 1);
+    let selection = chooseMealCandidate({
+      mealType,
+      sortedCandidates: mealCandidates,
+      usedIds: usedMealIds,
+      allowReuse,
+      remainingBudget: remainingMealBudget,
+      remainingMeals,
     });
-    activities = activities.concat(extra.map(e => ({...e, _category: "landmarks"})));
+
+    if (!selection) {
+      const fallbackPlace =
+        mealCandidates.find((candidate) => allowMealReuse || !usedMealIds.has(candidate.id)) ??
+        mealCandidates[0];
+      if (fallbackPlace) {
+        selection = {
+          place: fallbackPlace,
+          cost: estimateMealCostFromPriceLevel(mealType, fallbackPlace.priceLevel),
+        };
+      }
+    }
+
+    if (!selection) {
+      throw new Error("Unable to find meals for the itinerary.");
+    }
+
+    mealSelections[mealType] = selection;
+    usedMealIds.add(selection.place.id);
+    remainingMealBudget = Math.max(0, remainingMealBudget - selection.cost);
   }
-  const [am, pm] = [activities[0], activities[1]];
 
-  const breakfast = toActivity(b, "meal", "food", breakfastTime, 60, "breakfast");
-  const lunch     = toActivity(l, "meal", "food", lunchTime, 60, "lunch");
-  const dinner    = toActivity(d, "meal", "food", dinnerTime, 90, "dinner");
+  const breakfast = toActivity(mealSelections.breakfast.place, "meal", "food", breakfastTime, 60, "breakfast");
+  const lunch = toActivity(mealSelections.lunch.place, "meal", "food", lunchTime, 60, "lunch");
+  const dinner = toActivity(mealSelections.dinner.place, "meal", "food", dinnerTime, 90, "dinner");
 
-  const morning   = toActivity(am, "activity", am._category ?? "landmarks", addMinutes(breakfast.end!, 45), 120);
-  const afternoon = toActivity(pm, "activity", pm._category ?? "culture",    addMinutes(lunch.end!, 45), 150);
+  const mealsTotal = breakfast.estimatedCost + lunch.estimatedCost + dinner.estimatedCost;
+  let activityBudget = Math.max(0, perDay - mealsTotal);
+
+  const interestList =
+    params.interests && params.interests.length
+      ? params.interests
+      : (["landmarks", "parks"] as Interest[]);
+
+  let activityOptions = await findActivitiesNear(lat, lng, interestList);
+  if (activityOptions.length < 2) {
+    const extra = await nearbyPlaces({
+      lat,
+      lng,
+      radiusMeters: 5000,
+      includedTypes: ["tourist_attraction", "park"],
+      minRating: 4.0,
+      maxResults: 20,
+    });
+    activityOptions = activityOptions.concat(
+      extra.map((place) => ({ ...place, _category: "landmarks" as Interest })),
+    );
+  }
+  if (!activityOptions.length) {
+    activityOptions = [
+      {
+        id: g.placeId || `${lat},${lng}`,
+        name: `Explore ${g.name}`,
+        address: g.name,
+        lat,
+        lng,
+        googleMapsUri:
+          g.placeId
+            ? `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(g.name)}&query_place_id=${encodeURIComponent(
+                g.placeId,
+              )}`
+            : `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(g.name)}`,
+        rating: undefined,
+        userRatingsTotal: undefined,
+        priceLevel: 0,
+        websiteUri: undefined,
+        types: [],
+        _category: "landmarks" as Interest,
+      },
+    ];
+  }
+
+  const activityCandidates = sortPlacesByQuality(activityOptions);
+  const uniqueActivityIds = new Set(activityOptions.map((a) => a.id));
+  const allowActivityReuse = uniqueActivityIds.size < 2;
+  const blockedActivityIds = new Set<string>(Array.from(usedMealIds));
+  const usedActivityIds = new Set<string>();
+
+  const pickActivity = (slotsRemaining: number, budgetForSlot: number): ActivitySelection => {
+    let selection = chooseActivityCandidate({
+      sortedCandidates: activityCandidates,
+      usedIds: usedActivityIds,
+      blockedIds: blockedActivityIds,
+      allowReuse: allowActivityReuse,
+      budgetRemaining: budgetForSlot,
+      slotsRemaining,
+    });
+
+    if (!selection) {
+      const fallbackCandidate =
+        activityCandidates.find(
+          (candidate) =>
+            !usedActivityIds.has(candidate.id) && !blockedActivityIds.has(candidate.id),
+        ) ??
+        activityCandidates.find((candidate) => !usedActivityIds.has(candidate.id)) ??
+        activityCandidates[0];
+
+      if (fallbackCandidate) {
+        const category = (fallbackCandidate._category ?? "landmarks") as Interest;
+        const cost = estimateActivityCostFromPriceLevel(category, fallbackCandidate.priceLevel);
+        selection = { place: fallbackCandidate, cost, category };
+      }
+    }
+
+    if (!selection) {
+      throw new Error("Unable to find daytime activities.");
+    }
+
+    usedActivityIds.add(selection.place.id);
+    blockedActivityIds.add(selection.place.id);
+    return selection;
+  };
+
+  const morningSelection = pickActivity(1, activityBudget);
+  const morningStart = planStartAfter(breakfast, breakfastTime, 60, 45);
+  const morning = toActivity(
+    morningSelection.place,
+    "activity",
+    morningSelection.category,
+    morningStart,
+    120,
+  );
+  activityBudget = Math.max(0, perDay - (mealsTotal + morning.estimatedCost));
+
+  const afternoonSelection = pickActivity(0, activityBudget);
+  const afternoonStart = planStartAfter(lunch, lunchTime, 60, 45);
+  const afternoon = toActivity(
+    afternoonSelection.place,
+    "activity",
+    afternoonSelection.category,
+    afternoonStart,
+    150,
+  );
+
+  const baseTotal =
+    breakfast.estimatedCost +
+    lunch.estimatedCost +
+    dinner.estimatedCost +
+    morning.estimatedCost +
+    afternoon.estimatedCost;
 
   let evening: Activity | undefined;
-  const subtotal =
-    breakfast.estimatedCost + lunch.estimatedCost + dinner.estimatedCost +
-    morning.estimatedCost + afternoon.estimatedCost;
-  if (subtotal < perDay * 0.9) {
-    const nightlife = await nearbyPlaces({
-      lat, lng, radiusMeters: 3000, includedTypes: ["bar","night_club"], minRating: 4.2, maxResults: 10
+  let totalEstimatedCost = baseTotal;
+
+  const eveningBudget = Math.max(0, perDay - baseTotal);
+  if (eveningBudget >= 12) {
+    const nightlifeRaw = await nearbyPlaces({
+      lat,
+      lng,
+      radiusMeters: 3200,
+      includedTypes: ["bar", "night_club"],
+      minRating: 4.2,
+      maxResults: 12,
     });
-    if (nightlife[0]) {
-      evening = toActivity(nightlife[0], "activity", "nightlife", addMinutes(dinner.end!, 30), 90);
+    const nightlifeCandidates = sortPlacesByQuality(
+      nightlifeRaw.map((place) => ({ ...place, _category: "nightlife" as Interest })),
+    );
+    const eveningSelection = chooseActivityCandidate({
+      sortedCandidates: nightlifeCandidates,
+      usedIds: usedActivityIds,
+      blockedIds: blockedActivityIds,
+      allowReuse: true,
+      budgetRemaining: eveningBudget,
+      slotsRemaining: 0,
+    });
+
+    if (eveningSelection) {
+      const eveningStart = planStartAfter(dinner, dinnerTime, 90, 30);
+      const eveningActivity = toActivity(
+        eveningSelection.place,
+        "activity",
+        eveningSelection.category,
+        eveningStart,
+        90,
+      );
+      const projectedTotal = baseTotal + eveningActivity.estimatedCost;
+      if (projectedTotal <= perDay + 5) {
+        evening = eveningActivity;
+        totalEstimatedCost = projectedTotal;
+      }
     }
   }
 
-  const totalEstimatedCost = Math.round(
-    breakfast.estimatedCost + lunch.estimatedCost + dinner.estimatedCost +
-    morning.estimatedCost + afternoon.estimatedCost + (evening?.estimatedCost ?? 0)
-  );
-
   if (totalEstimatedCost > perDay && evening) {
+    totalEstimatedCost = baseTotal;
     evening = undefined;
   }
+
+  totalEstimatedCost = Math.round(Math.min(totalEstimatedCost, perDay));
 
   return {
     date: params.dateISO,
@@ -225,7 +537,7 @@ export async function createDayPlan(params: {
     afternoon,
     dinner,
     evening,
-    totalEstimatedCost: Math.min(perDay, totalEstimatedCost),
+    totalEstimatedCost,
   };
 }
 

--- a/src/hooks/usePlanner.ts
+++ b/src/hooks/usePlanner.ts
@@ -104,6 +104,8 @@ const usePlanner = () => {
         total_estimated_cost: convertValue(source.total_estimated_cost),
         budget_converted:
           source.budget_usd != null ? convertValue(source.budget_usd) : undefined,
+        daily_budget_converted:
+          source.daily_budget_usd != null ? convertValue(source.daily_budget_usd) : undefined,
         days: convertedDays,
       };
     },

--- a/src/screens/SavedPlansScreen.tsx
+++ b/src/screens/SavedPlansScreen.tsx
@@ -190,11 +190,18 @@ const SavedPlansScreen = () => {
             1;
           const currency = itineraryData?.currency ?? 'USD';
           const symbol = currencySymbols[currency] ?? '$';
-          const budgetDisplay =
-            itineraryData?.budget_converted ?? itineraryData?.budget_usd;
-          const budgetLabel = budgetDisplay
-            ? `${symbol}${budgetDisplay.toFixed(0)} per day`
-            : 'Flexible budget';
+          const totalBudget =
+            itineraryData?.budget_converted ?? itineraryData?.budget_usd ?? null;
+          const dailyBudget =
+            itineraryData?.daily_budget_converted ??
+            itineraryData?.daily_budget_usd ??
+            (totalBudget != null
+              ? totalBudget / Math.max(durationDays, 1)
+              : null);
+          const budgetLabel =
+            dailyBudget != null
+              ? `${symbol}${dailyBudget.toFixed(0)} per day`
+              : 'Flexible budget';
 
           return (
             <Surface key={trip.id} style={styles.tripCard} elevation={1}>

--- a/src/types/plans.ts
+++ b/src/types/plans.ts
@@ -60,6 +60,8 @@ export type TripItinerary = {
   base_currency: 'USD';
   budget_usd?: number;
   budget_converted?: number;
+  daily_budget_usd?: number;
+  daily_budget_converted?: number;
   total_estimated_cost: number;
   highlights: string[];
   weatherSummary?: string;


### PR DESCRIPTION
## Summary
- add deterministic meal and activity ranking helpers so day plans use high-quality, budget-aware Google Places results
- rewrite the day-planner pipeline to enforce three meals, interstitial activities, nightly nightlife when affordable, and fallbacks when data is sparse
- keep itinerary conversion logic aligned with the new engine output (meals, activities, travel legs, budgets)

## Testing
- npm run lint *(fails: repository still uses legacy .eslintrc configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d37c8d7f14832ca8e73d2507f68dc9